### PR TITLE
Iss #36 account for remote sensing devices in the data model

### DIFF
--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -386,7 +386,7 @@
           "logger_main_config": {
             "type": "array",
             "title": "Logger Configuration",
-            "description": "This represents how the logger's main settings are configured. For example, it's sampling rate or averaging period.",
+            "description": "This represents how the logger's main settings are configured. For example, it's sampling rate or averaging period. For remote sensing devices, such as lidar's, the device itself is considered as a logger and so these logger configuration attributes should be used to describe the lidar.",
             "items": {
               "type": "object",
               "title": "Logger Configuration",
@@ -394,7 +394,7 @@
                 "logger_oem_id": {
                   "type": "string",
                   "title": "Logger OEM",
-                  "description": "This is the logger manufacturer id as defined by the IEA Wind Resource Assessment Data Model Schema.",
+                  "description": "This is the logger or remote sensing device manufacturer id as defined by the IEA Wind Resource Assessment Data Model Schema.",
                   "enum": [
                     "NRG Systems",
                     "Ammonit",
@@ -405,6 +405,10 @@
                     "Wilmers",
                     "Unidata",
                     "WindLogger",
+                    "Leosphere",
+                    "ZX Lidars",
+                    "AXYS Technologies",
+                    "AQSystem",
                     "Other"
                   ]
                 },
@@ -414,17 +418,18 @@
                     "null"
                   ],
                   "title": "Logger Model Name",
-                  "description": "This is the logger model name. This is usually stated in the data files from the logger in either the header or footer.",
+                  "description": "This is the logger or remote sensing device model name. This is usually stated in the data files from the logger in either the header or footer.",
                   "examples": [
                     "Symphonie Plus3",
                     "CR1000",
-                    "Meteo-40M"
+                    "Meteo-40M",
+                    "WindCube v2"
                   ]
                 },
                 "logger_serial_number": {
                   "type": "string",
                   "title": "Logger Serial Number",
-                  "description": "The logger serial number. This is sometimes different from the logger id."
+                  "description": "The logger or remote sensing device serial number. This is sometimes different from the logger id."
                 },
                 "logger_id": {
                   "type": [
@@ -432,7 +437,7 @@
                     "null"
                   ],
                   "title": "Logger Id",
-                  "description": "This is the logger id. It may be set by the logger programmer and may be different from the logger serial number.",
+                  "description": "This is the logger or remote sensing device id. It may be set by the logger programmer and may be different from the logger serial number.",
                   "examples": [
                     "4321",
                     "D123456"

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -151,12 +151,13 @@
           },
           "measurement_station_type_id": {
             "title": "Measurement Station Type",
-            "description": "The type of measurement station. This must be one of either mast, lidar or sodar.",
+            "description": "The type of measurement station. This must be one of either met mast, lidar, sodar or flidar (floating lidar).",
             "type": "string",
             "enum": [
               "mast",
               "lidar",
-              "sodar"
+              "sodar",
+              "flidar"
             ]
           },
           "notes": {

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -406,6 +406,18 @@
                     1
                   ]
                 },
+                "device_base_height_m": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "title": "Device Base Height [m]",
+                  "description": "The height of the base of the remote sensing device e.g. above ground level. This is usually the height above ground level at which the remote sensing device is mounted however it may be above sea level or above a platform level.",
+                  "examples": [
+                    0.5,
+                    1
+                  ]
+                },
                 "height_reference_id": {
                   "type": [
                     "string",

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -739,6 +739,10 @@
                     "illuminance",
                     "status",
                     "counter",
+                    "availability",
+                    "quality",
+                    "carrier_to_noise_ratio",
+                    "doppler_spectral_broadening",
                     "other"
                   ]
                 },
@@ -824,6 +828,7 @@
                           "W/m^2",
                           "m/s^2",
                           "lux",
+                          "dB",
                           "-"
                         ]
                       },
@@ -886,11 +891,14 @@
                                 "max",
                                 "min",
                                 "count",
+                                "availability",
+                                "quality",
                                 "sum",
                                 "median",
                                 "mode",
                                 "range",
                                 "gust",
+                                "ti",
                                 "text"
                               ]
                             },

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -562,6 +562,40 @@
                 },
                 "update_at": {
                   "$ref": "#/definitions/update_at"
+                },
+                "lidar_config": {
+                  "type": "array",
+                  "title": "Lidar Specific Configuration",
+                  "description": "The lidar specific configuration represents how the lidar's specific settings are configured. For example, if FCR is turned on.",
+                  "items": {
+                    "type": "object",
+                    "title": "Lidar Specific  Configuration",
+                    "properties": {
+                      "flow_corrections_applied": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ],
+                        "title": "Flow Corrections Applied",
+                        "description": "Is there any flow corrections applied to the measured data by the lidar unit, e.g. FCR for WindCubes?",
+                        "examples": [
+                          "true for any flow corrections applied.",
+                          "false for no flow corrections applied."
+                        ]
+                      },
+                      "notes": {
+                        "$ref": "#/definitions/notes"
+                      },
+                      "update_at": {
+                        "$ref": "#/definitions/update_at"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                    ]
+                  },
+                  "additionalItems": false,
+                  "uniqueItems": true
                 }
               },
               "additionalProperties": false,

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -383,16 +383,16 @@
             },
             "additionalProperties": false
           },
-          "vertical_profiling_properties":{
+          "vertical_profiler_properties":{
             "type": [
               "array",
               "null"
             ],
-            "title": "Vertical Profiling Properties",
-            "description": "Vertical profiling remote sensing devices installation specific properties.",
+            "title": "Vertical Profiler Properties",
+            "description": "Vertical profiler remote sensing devices installation specific properties.",
             "items": {
               "type": "object",
-              "title": "Vertical Profiling Properties",
+              "title": "Vertical Profiler Properties",
               "properties": {
                 "window_height_m": {
                   "type": [

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -151,7 +151,7 @@
           },
           "measurement_station_type_id": {
             "title": "Measurement Station Type",
-            "description": "The type of measurement station. This must be one of either met mast, lidar, sodar or flidar (floating lidar).",
+            "description": "The type of measurement station. This must be one of either met mast, lidar (a vertical profiler), sodar (also a vertical profiler) or flidar (floating vertical profiler lidar).",
             "type": "string",
             "enum": [
               "mast",
@@ -389,30 +389,18 @@
               "null"
             ],
             "title": "Vertical Profiler Properties",
-            "description": "Vertical profiler remote sensing devices installation specific properties.",
+            "description": "Vertical profiler remote sensing devices (e.g. lidar, sodar and flidar) installation specific properties.",
             "items": {
               "type": "object",
               "title": "Vertical Profiler Properties",
               "properties": {
-                "window_height_m": {
+                "device_datum_plane_height_m": {
                   "type": [
                     "number",
                     "null"
                   ],
-                  "title": "Window Height [m]",
-                  "description": "The window height of the lidar device. This is usually the height of window above ground level however it may be above sea level or above a platform level.",
-                  "examples": [
-                    0.5,
-                    1
-                  ]
-                },
-                "device_base_height_m": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "title": "Device Base Height [m]",
-                  "description": "The height of the base of the remote sensing device e.g. above ground level. This is usually the height above ground level at which the remote sensing device is mounted however it may be above sea level or above a platform level.",
+                  "title": "Device Datum Plane Height [m]",
+                  "description": "The datum plane height of the remote sensing device where the datum feature is defined here: https://data.windenergy.dtu.dk/ontologies/view/IEATask32Glossary/en/page/parameters.datum_feature . For lidars the datum feature is usually the window and for sodars it is usually the base of the device. These datum plane heights are also usually referred to as above ground level however it may be above sea level or above a platform level.",
                   "examples": [
                     0.5,
                     1
@@ -424,7 +412,7 @@
                     "null"
                   ],
                   "title": "Height Reference",
-                  "description": "The height reference frame that is used to measure the height of the window. E.g. onshore this is ground level i.e. the window is 0.5 m above ground level. Offshore is a bit different as it can be 20 m above mean sea level or 20 m above lowest astronomical tide.",
+                  "description": "The height reference frame that is used to measure the device datum plane height. E.g. onshore this is ground level i.e. the datum feature is 0.5 m above ground level. Offshore is a bit different as it can be 20 m above mean sea level or 20 m above lowest astronomical tide.",
                   "enum": [
                     "ground_level",
                     "mean_sea_level",
@@ -502,6 +490,7 @@
                     "ZX Lidars",
                     "AXYS Technologies",
                     "AQSystem",
+                    "Pentaluum",
                     "Other"
                   ]
                 },
@@ -533,7 +522,8 @@
                   "description": "This is the logger or remote sensing device id. It may be set by the logger programmer and may be different from the logger serial number.",
                   "examples": [
                     "4321",
-                    "D123456"
+                    "D123456",
+                    "WLS7-999"
                   ]
                 },
                 "logger_name": {
@@ -665,7 +655,7 @@
                   "description": "The lidar specific configuration represents how the lidar's specific settings are configured. For example, if FCR is turned on.",
                   "items": {
                     "type": "object",
-                    "title": "Lidar Specific  Configuration",
+                    "title": "Lidar Specific Configuration",
                     "properties": {
                       "flow_corrections_applied": {
                         "type": [
@@ -673,10 +663,10 @@
                           "null"
                         ],
                         "title": "Flow Corrections Applied",
-                        "description": "Is there any flow corrections applied to the measured data by the lidar unit, e.g. FCR for WindCubes?",
+                        "description": "Is there any flow corrections applied to the measured data by the lidar unit, e.g. Flow Complexity Recognition (FCR) for WindCubes?",
                         "examples": [
-                          "true for any flow corrections applied.",
-                          "false for no flow corrections applied."
+                          "true (for any flow corrections applied)",
+                          "false (for no flow corrections applied)"
                         ]
                       },
                       "date_from": {

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -748,7 +748,7 @@
                     "null"
                   ],
                   "title": "Height [m]",
-                  "description": "The height (in meters) typically above ground level that measurement is taking place. If you do not yet know the height please use null."
+                  "description": "The height (in meters) typically above ground level that the measurement is taking place. If you do not yet know the height please use null."
                 },
                 "height_reference_id": {
                   "type": [
@@ -833,7 +833,7 @@
                           "null"
                         ],
                         "title": "Logger Height [m]",
-                        "description": "The height above ground level in meters at which the sensor is deployed as programmed into the logger."
+                        "description": "The height in meters at which the sensor is deployed, as programmed into the logger. For remote sensing devices such as lidars and sodars this is the measurement height programmed into the device where the measurement height is defined here: http://data.windenergy.dtu.dk/controlled-terminology/IEAWindTask32/parameters.measurement_height"
                       },
                       "serial_number": {
                         "type": [

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -383,6 +383,87 @@
             },
             "additionalProperties": false
           },
+          "vertical_profiling_properties":{
+            "type": [
+              "array",
+              "null"
+            ],
+            "title": "Vertical Profiling Properties",
+            "description": "Vertical profiling remote sensing devices installation specific properties.",
+            "items": {
+              "type": "object",
+              "title": "Vertical Profiling Properties",
+              "properties": {
+                "window_height_m": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "title": "Window Height [m]",
+                  "description": "The window height of the lidar device. This is usually the height of window above ground level however it may be above sea level or above a platform level.",
+                  "examples": [
+                    0.5,
+                    1
+                  ]
+                },
+                "height_reference_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "title": "Height Reference",
+                  "description": "The height reference frame that is used to measure the height of the window. E.g. onshore this is ground level i.e. the window is 0.5 m above ground level. Offshore is a bit different as it can be 20 m above mean sea level or 20 m above lowest astronomical tide.",
+                  "enum": [
+                    "ground_level",
+                    "mean_sea_level",
+                    "lowest_astronomical_tide",
+                    "other"
+                  ],
+                  "default": "ground_level"
+                },
+                "device_orientation_deg": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "title": "Device Orientation [deg]",
+                  "description": "The orientation that the remote sensing device is installed relative to north.",
+                  "minimum": 0,
+                  "maximum": 360
+                },
+                "orientation_reference_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "title": "Orientation Reference",
+                  "description": "The orientation reference the remote sensing device is measured against. E.g. magnetic north.",
+                  "enum": [
+                    "magnetic_north",
+                    "true_north",
+                    "grid_north"
+                  ]
+                },
+                "date_from": {
+                  "$ref": "#/definitions/date_from"
+                },
+                "date_to": {
+                  "$ref": "#/definitions/date_to"
+                },
+                "notes": {
+                  "$ref": "#/definitions/notes"
+                },
+                "update_at": {
+                  "$ref": "#/definitions/update_at"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+              ]
+            },
+            "additionalItems": false,
+            "uniqueItems": true
+          },
           "logger_main_config": {
             "type": "array",
             "title": "Logger Configuration",
@@ -564,7 +645,10 @@
                   "$ref": "#/definitions/update_at"
                 },
                 "lidar_config": {
-                  "type": "array",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "title": "Lidar Specific Configuration",
                   "description": "The lidar specific configuration represents how the lidar's specific settings are configured. For example, if FCR is turned on.",
                   "items": {
@@ -582,6 +666,12 @@
                           "true for any flow corrections applied.",
                           "false for no flow corrections applied."
                         ]
+                      },
+                      "date_from": {
+                        "$ref": "#/definitions/date_from"
+                      },
+                      "date_to": {
+                        "$ref": "#/definitions/date_to"
                       },
                       "notes": {
                         "$ref": "#/definitions/notes"

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -241,7 +241,7 @@ CREATE TABLE IF NOT EXISTS mast_section_geometry(
     FOREIGN KEY (mast_properties_uuid) REFERENCES mast_properties (uuid)
 );
 
-CREATE TABLE IF NOT EXISTS vertical_profiling_properties(
+CREATE TABLE IF NOT EXISTS vertical_profiler_properties(
     uuid UUID PRIMARY KEY,
     measurement_location_uuid UUID,
     window_height_m decimal,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -288,6 +288,8 @@ CREATE TABLE IF NOT EXISTS lidar_config(
     uuid UUID PRIMARY KEY,
     logger_main_config_uuid UUID,
     flow_corrections_applied boolean,
+    date_from timestamp WITHOUT TIME ZONE NOT NULL,
+    date_to timestamp WITHOUT TIME ZONE,
     notes text,
     update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by UUID,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -241,6 +241,22 @@ CREATE TABLE IF NOT EXISTS mast_section_geometry(
     FOREIGN KEY (mast_properties_uuid) REFERENCES mast_properties (uuid)
 );
 
+CREATE TABLE IF NOT EXISTS vertical_profiling_properties(
+    uuid UUID PRIMARY KEY,
+    measurement_location_uuid UUID,
+    window_height_m decimal,
+    height_reference_id text DEFAULT 'ground_level',
+    device_orientation_deg decimal CHECK (device_orientation_deg >= 0 AND device_orientation_deg <= 360),
+    orientation_reference_id text,
+    date_from timestamp WITHOUT TIME ZONE NOT NULL,
+    date_to timestamp WITHOUT TIME ZONE,
+    notes text,
+    update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_by UUID,
+    FOREIGN KEY (measurement_location_uuid) REFERENCES measurement_location (uuid),
+    FOREIGN KEY (height_reference_id) REFERENCES height_reference (id),
+    FOREIGN KEY (orientation_reference_id) REFERENCES orientation_reference (id)
+);
 
 CREATE TABLE IF NOT EXISTS logger_main_config(
     uuid UUID PRIMARY KEY,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -78,10 +78,10 @@ INSERT INTO logger_oem (id) VALUES
     ('Wilmers'),
     ('Unidata'),
     ('WindLogger'),
-    ("Leosphere"),
-    ("ZX Lidars"),
-    ("AXYS Technologies"),
-    ("AQSystem"),
+    ('Leosphere'),
+    ('ZX Lidars'),
+    ('AXYS Technologies'),
+    ('AQSystem'),
     ('other');
 
 INSERT INTO measurement_type (id) VALUES
@@ -265,6 +265,16 @@ CREATE TABLE IF NOT EXISTS logger_main_config(
     updated_by UUID,
     FOREIGN KEY (measurement_location_uuid) REFERENCES measurement_location (uuid),
     FOREIGN KEY (logger_oem_id) REFERENCES logger_oem (id)
+);
+
+CREATE TABLE IF NOT EXISTS lidar_config(
+    uuid UUID PRIMARY KEY,
+    logger_main_config_uuid UUID,
+    flow_corrections_applied boolean,
+    notes text,
+    update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_by UUID,
+    FOREIGN KEY (logger_main_config_uuid) REFERENCES logger_main_config (uuid)
 );
 
 CREATE TABLE IF NOT EXISTS measurement_point(

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -105,6 +105,10 @@ INSERT INTO measurement_type (id) VALUES
     ('illuminance'),
     ('status'),
     ('counter'),
+    ('availability'),
+    ('quality'),
+    ('carrier_to_noise_ratio'),
+    ('doppler_spectral_broadening'),
     ('other');
 
 INSERT INTO height_reference (id) VALUES
@@ -130,6 +134,7 @@ INSERT INTO measurement_units (id) VALUES
     ('W/m^2'),
     ('m/s^2'),
     ('lux'),
+    ('dB'),
     ('-');
 
 INSERT INTO statistic_type (id) VALUES
@@ -138,11 +143,14 @@ INSERT INTO statistic_type (id) VALUES
     ('max'),
     ('min'),
     ('count'),
+    ('availability'),
+    ('quality'),
     ('sum'),
     ('median'),
     ('mode'),
     ('range'),
     ('gust'),
+    ('ti'),
     ('text');
 
 INSERT INTO sensor_type (id) VALUES

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -82,6 +82,7 @@ INSERT INTO logger_oem (id) VALUES
     ('ZX Lidars'),
     ('AXYS Technologies'),
     ('AQSystem'),
+    ('Pentaluum'),
     ('other');
 
 INSERT INTO measurement_type (id) VALUES
@@ -244,8 +245,7 @@ CREATE TABLE IF NOT EXISTS mast_section_geometry(
 CREATE TABLE IF NOT EXISTS vertical_profiler_properties(
     uuid UUID PRIMARY KEY,
     measurement_location_uuid UUID,
-    window_height_m decimal,
-    device_base_height_m decimal,
+    device_datum_plane_height_m decimal,
     height_reference_id text DEFAULT 'ground_level',
     device_orientation_deg decimal CHECK (device_orientation_deg >= 0 AND device_orientation_deg <= 360),
     orientation_reference_id text,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -245,6 +245,7 @@ CREATE TABLE IF NOT EXISTS vertical_profiling_properties(
     uuid UUID PRIMARY KEY,
     measurement_location_uuid UUID,
     window_height_m decimal,
+    device_base_height_m decimal,
     height_reference_id text DEFAULT 'ground_level',
     device_orientation_deg decimal CHECK (device_orientation_deg >= 0 AND device_orientation_deg <= 360),
     orientation_reference_id text,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -78,6 +78,10 @@ INSERT INTO logger_oem (id) VALUES
     ('Wilmers'),
     ('Unidata'),
     ('WindLogger'),
+    ("Leosphere"),
+    ("ZX Lidars"),
+    ("AXYS Technologies"),
+    ("AQSystem"),
     ('other');
 
 INSERT INTO measurement_type (id) VALUES

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -60,7 +60,8 @@ INSERT INTO plant_type (id) VALUES
 INSERT INTO measurement_station_type (id) VALUES
     ('mast'),
     ('lidar'),
-    ('sodar');
+    ('sodar'),
+    ('flidar');
 
 INSERT INTO mast_geometry (id) VALUES
     ('lattice_triangle'),


### PR DESCRIPTION
Hi @kersting and @abohara,

I have finally made those changes we discussed at the last meeting.

I have also added in date_from and date_to to the lidar_config as the flow corrections could be turned on or off at any point during a measurement campaign.

I have also added a 'device_base_height' to account for either a sodar or lidar. If a lidar, the user can populate the 'window_height' and not worry about the 'device_base_height'.

Please could you both review and see what you think of these changes for remote sensing.

Thanks.