### PR TITLE
iss #48 correct spelling of Uncertainty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Additional labels for pre-release and build metadata are available as extensions
 
 ## [Unreleased]
 - Initial release
+- Correct 'Uncertainty' property spelling under Calibration Uncertainty.
 
 ## [0.1.0-YYYY.MM]

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1245,7 +1245,7 @@
                                       "number",
                                       "null"
                                     ],
-                                    "title": "Reference Unit",
+                                    "title": "Uncertainty",
                                     "description": "The uncertainty associated with this reference bin.",
                                     "examples": [
                                       0.1


### PR DESCRIPTION
iss #48 correct the spelling of Uncertainty under Calibration Uncertainty. It was Reference Unit.