### PR TITLE
iss #55 header additional props true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Additional labels for pre-release and build metadata are available as extensions
 
 ## [Unreleased]
 - Initial release
+- Allow additional properties for header section of schema.
 
 ## [0.1.0-YYYY.MM]

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1539,7 +1539,7 @@
       "uniqueItems": true
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "author",
     "organisation",


### PR DESCRIPTION
From issue #55 allow other properties for the header section of the schema. This is not for the main schema outlining the met mast.