### PR TITLE
Iss #68 sensor config rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
+## [0.2.0-2021.XX]
+- Rename `sensor_config` to `logger_measurement_config`
 
 ## [0.1.1-2021.04]
 - Allow additional properties for header section of schema.

--- a/demo_data/iea43_wra_data_model.json
+++ b/demo_data/iea43_wra_data_model.json
@@ -61,7 +61,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04573,
         "offset": 0.2419,
         "sensitivity": null,
@@ -252,7 +252,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04568,
         "offset": 0.2487,
         "sensitivity": null,
@@ -520,7 +520,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04666,
         "offset": 0.2416,
         "sensitivity": null,
@@ -663,7 +663,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04777,
         "offset": 0.2417,
         "sensitivity": null,
@@ -806,7 +806,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04888,
         "offset": 0.2418,
         "sensitivity": null,
@@ -987,7 +987,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04999,
         "offset": 0.2419,
         "sensitivity": null,
@@ -1130,7 +1130,7 @@
       "height_reference_id": "ground_level",
       "notes": "Anemometer put in wrong place. Moved to 40m.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.04999,
         "offset": 0.2419,
         "sensitivity": null,
@@ -1273,7 +1273,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.351,
         "offset": null,
         "sensitivity": null,
@@ -1351,7 +1351,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.351,
         "offset": null,
         "sensitivity": null,
@@ -1459,7 +1459,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.136,
         "offset": -86.383,
         "sensitivity": null,
@@ -1519,7 +1519,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 100,
         "offset": -30,
         "sensitivity": null,
@@ -1579,7 +1579,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 100,
         "offset": 0,
         "sensitivity": null,
@@ -1639,7 +1639,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.4255,
         "offset": 650,
         "sensitivity": null,
@@ -1699,7 +1699,7 @@
       "height_reference_id": "ground_level",
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
-      "sensor_config": [{
+      "logger_measurement_config": [{
         "slope": 0.021,
         "offset": 0,
         "sensitivity": null,

--- a/demo_data/iea43_wra_data_model.json
+++ b/demo_data/iea43_wra_data_model.json
@@ -2,7 +2,7 @@
   "author": "Stephen Holleran",
   "organisation": "brightwind",
   "date": "2020-06-07",
-  "version": "0.1.0-2021.01",
+  "version": "0.2.0-2021.XX",
   "plant_name": "A Name of Wind Farm",
   "plant_type": "onshore_wind",
   "measurement_location": [{

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$version": "0.1.1-2021.04",
+  "$version": "0.2.0-2021.XX",
   "$id": "https://raw.githubusercontent.com/IEA-Task-43/digital_wra_data_standard/master/schema/iea43_wra_data_model.schema.json",
   "definitions": {
     "date_from": {

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -842,13 +842,13 @@
                 "update_at": {
                   "$ref": "#/definitions/update_at"
                 },
-                "sensor_config": {
+                "logger_measurement_config": {
                   "type": "array",
-                  "title": "Sensor Configuration",
-                  "description": "The sensor configuration that is programmed into the logging device.",
+                  "title": "Logger Measurement Configuration",
+                  "description": "The measurement configuration that is programmed into the logging device.",
                   "items": {
                     "type": "object",
-                    "title": "Sensor Configuration",
+                    "title": "Logger Measurement Configuration",
                     "properties": {
                       "slope": {
                         "type": [
@@ -1540,7 +1540,7 @@
                 "name",
                 "measurement_type_id",
                 "height_m",
-                "sensor_config"
+                "logger_measurement_config"
               ]
             },
             "additionalItems": false,

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -362,7 +362,7 @@ CREATE TABLE IF NOT EXISTS measurement_point(
     FOREIGN KEY (height_reference_id) REFERENCES height_reference (id)
 );
 
-CREATE TABLE IF NOT EXISTS sensor_config(
+CREATE TABLE IF NOT EXISTS logger_measurement_config(
     uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     measurement_point_uuid UUID NOT NULL,
     slope decimal,
@@ -383,14 +383,14 @@ CREATE TABLE IF NOT EXISTS sensor_config(
 
 CREATE TABLE IF NOT EXISTS column_name(
     uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    sensor_config_uuid UUID NOT NULL,
+    logger_measurement_config_uuid UUID NOT NULL,
     column_name text NOT NULL,
     statistic_type_id text NOT NULL,
     is_ignored boolean NOT NULL DEFAULT false,
     notes text,
     update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by UUID,
-    FOREIGN KEY (sensor_config_uuid) REFERENCES sensor_config (uuid),
+    FOREIGN KEY (logger_measurement_config_uuid) REFERENCES logger_measurement_config (uuid),
     FOREIGN KEY (statistic_type_id) REFERENCES statistic_type (id)
 );
 


### PR DESCRIPTION
From issue #68 this is to rename the `sensor_config` to `logger_measurement_config' to better represent what is in the section/table.

This is a breaking change so I have iterated the version to 0.2.0. As we are still in version 0 I think it is fair to put breaking changes into the second digit until we get to a version 1.