### PR TITLE
iss #79 move date_from and date_to into meas_point_sensor table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional labels for pre-release and build metadata are available as extensions
 
 ## [0.2.0-2021.XX]
 - Rename `sensor_config` to `logger_measurement_config`
+- In the create table SQL statements contained in file 'iea43_wra_data_model_postgresql.sql' move `date_from` and `date_to` from the `sensor` table into the `measurement_point_sensor` table. Note: This has no impact on the JSON Schema.
 
 ## [0.1.1-2021.04]
 - Allow additional properties for header section of schema.

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -402,8 +402,6 @@ CREATE TABLE IF NOT EXISTS sensor(
     sensor_type_id text,
     instrument_poi_height_mm decimal,
     is_heated boolean,
-    date_from timestamp WITHOUT TIME ZONE NOT NULL,
-    date_to timestamp WITHOUT TIME ZONE,
     notes text,
     update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by UUID,
@@ -413,6 +411,8 @@ CREATE TABLE IF NOT EXISTS sensor(
 CREATE TABLE IF NOT EXISTS measurement_point_sensor(
     measurement_point_uuid UUID,
     sensor_uuid UUID,
+    date_from timestamp WITHOUT TIME ZONE NOT NULL,
+    date_to timestamp WITHOUT TIME ZONE,
     PRIMARY KEY (measurement_point_uuid, sensor_uuid),
     FOREIGN KEY (measurement_point_uuid) REFERENCES measurement_point (uuid),
     FOREIGN KEY (sensor_uuid) REFERENCES sensor (uuid)


### PR DESCRIPTION
From issue #79 
Move the `date_from` and `date_to` attributes from the `sensor` table into the `measurement_point_sensor` mapping table instead.

Note; this has no impact on the JSON Schema. It just helps organize the relational diagram better.