### PR TITLE
iss #91 add solar to measurement type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional labels for pre-release and build metadata are available as extensions
 ## [0.2.0-2021.XX]
 - Rename `sensor_config` to `logger_measurement_config`
 - In the create table SQL statements contained in file 'iea43_wra_data_model_postgresql.sql' move `date_from` and `date_to` from the `sensor` table into the `measurement_point_sensor` table. Note: This has no impact on the JSON Schema.
+- Add `solar` to `measurement_type_id`
 
 ## [0.1.1-2021.04]
 - Allow additional properties for header section of schema.

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -159,7 +159,8 @@
               "mast",
               "lidar",
               "sodar",
-              "flidar"
+              "flidar",
+              "solar"
             ]
           },
           "notes": {

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -69,7 +69,8 @@ INSERT INTO measurement_station_type (id) VALUES
     ('mast'),
     ('lidar'),
     ('sodar'),
-    ('flidar');
+    ('flidar'),
+    ('solar');
 
 INSERT INTO mast_geometry (id) VALUES
     ('lattice_triangle'),


### PR DESCRIPTION
From issue #91.
Add `solar` to `measurement_type_id` to be compliant with allowing solar as a plant.