### PR TITLE
iss #103 add revision to calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ Additional labels for pre-release and build metadata are available as extensions
 - To `measurement_station_type` enum, added:
    - solar
 - Converted `measurement_type_id` to a definition.
-- To `calibration` object, added `measurement_type_id` reference.
+- To `calibration` object, added:
+   - `measurement_type_id` (Issue [#96](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/96))
+   - `revision` (Issue [#103](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/103))
+
 
 ## [0.1.1-2021.04]
 - Allow additional properties for header section of schema.

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1210,6 +1210,18 @@
                                 "2019-12-06"
                               ]
                             },
+                            "revision": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "title": "Calibration Revision",
+                              "description": "This is the revision number or other identifier if the calibration report was revised. The 'date of calibration' and 'calibration id' may stay the same for an update to the report and so this revision field allows this report to be uniquely identified.",
+                              "examples": [
+                                "2.0",
+                                "B"
+                              ]
+                            },
                             "calibration_organisation": {
                               "type": [
                                 "string",

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -434,6 +434,7 @@ CREATE TABLE IF NOT EXISTS calibration(
     report_link text,
     calibration_id text,
     date_of_calibration date,
+    revision text,
     calibration_organisation text,
     place_of_calibration text,
     uncertainty_k_factor decimal,


### PR DESCRIPTION
Issue #103 

Adding revision to the calibration as the report can be updated but no date or id changing. This is needed to make it unique.