### PR TITLE
Fixing issue 168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,10 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
-## [1.1.0-2022.05]
-1. Included `number_of_repetitive_patterns_on_face` to `mast_section_geometry`. (Issue [#152] (https://github.com/IEA-Task-43/digital_wra_data_standard/issues/152)
-1. Included `mast_section_height_mm` to `mast_section_geometry`. (Issue [#152] (https://github.com/IEA-Task-43/digital_wra_data_standard/issues/152)
-1. Included `uncertainty_k_factor` to `logger_main_config`. (Issue [#166] (https://github.com/IEA-Task-43/digital_wra_data_standard/issues/166)
-1. Included `diameter_of_interference_structure_mm` to `interference_structures`. (Issue [#156] (https://github.com/IEA-Task-43/digital_wra_data_standard/issues/156)
-1. Included additional enums to `measurement_units_id` in `logger_measurement_config` [mph, knots, atm, mmHg, inHg]. (Issue [#164] (https://github.com/IEA-Task-43/digital_wra_data_standard/issues/164)
-1. Modified example iea43_wra_data_model.json to include more realistic numbers for mast_section_geometry table.
-
 ## [1.X.X-2022.XX]
-1. Incorporating lightning finial diameter. (Issue [#156](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/156))
+1. To `mast_section_geometry`
+	1. `lattice_bracing_member_diameter_horizontal_mm` (Issue [#168](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/168))
+	1. `lattice_bracing_member_diameter_diagonal_mm` (Issue [#168](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/168))
 
 ## [1.0.0-2022.01]
 1. Incorporating the first version of the [Digital Calibration Certificate](./digital_calibration_certificate). (Issue [#77](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/77))

--- a/demo_data/iea43_wra_data_model.json
+++ b/demo_data/iea43_wra_data_model.json
@@ -29,6 +29,8 @@
         "lattice_leg_width_mm": 50,
         "lattice_leg_is_round_cross_section": true,
         "lattice_bracing_member_diameter_mm": 12,
+		"lattice_bracing_member_diameter_horizontal_mm": 12,
+		"lattice_bracing_member_diameter_diagonal_mm": 12,
         "lattice_number_of_diagonal_bracing_members": 8,
 		"number_of_repetitive_patterns_on_face": 4,
         "lattice_bracing_member_height_mm": 1486,

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -467,6 +467,28 @@
                         "null"
                       ],
                       "title": "Lattice Bracing Member Diameter [mm]",
+                      "description": "THIS FIELD WILL BE REMOVED IN THE NEXT MAJOR RELEASE. The lattice diagonal bracing member diameter.",
+                      "examples": [
+                        12
+                      ]
+                    },
+					"lattice_bracing_member_diameter_horizontal_mm": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "title": "Lattice Bracing Member Diameter Horizontal [mm]",
+                      "description": "The lattice horizontal bracing member diameter.",
+                      "examples": [
+                        12
+                      ]
+                    },
+					"lattice_bracing_member_diameter_diagonal_mm": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "title": "Lattice Bracing Member Diameter Diagonal [mm]",
                       "description": "The lattice diagonal bracing member diameter.",
                       "examples": [
                         12

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -298,6 +298,8 @@ CREATE TABLE IF NOT EXISTS mast_section_geometry(
     lattice_leg_width_mm decimal,
     lattice_leg_is_round_cross_section boolean,
     lattice_bracing_member_diameter_mm decimal,
+	lattice_bracing_member_diameter_horizontal_mm integer,
+	lattice_bracing_member_diameter_diagonal_mm integer,
     lattice_number_of_diagonal_bracing_members integer,
 	number_of_repetitive_patterns_on_face integer,
     lattice_bracing_member_height_mm decimal,


### PR DESCRIPTION
Split the bracing members in two parts but kept the original one to ensure that it does not break current applications developed with old field.