### PR TITLE
iss #150 add meas_point log_meas_cfg mapping table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional labels for pre-release and build metadata are available as extensions
 1. To `measurement_units_id` added:
    1. mph, knots, atm, mmHg, inHg (Issue [#164](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/164))
    1. kg/m^3 (THE INCORRECT 'kg/m^2' WILL BE DEPRECIATED IN THE NEXT RELEASE) (Issue [#165](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/165))
+1. Add a mapping table between `meas_point` and `logger_meas_config` in the SQL database. (Issue [#150](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/150))
 
 
 ## [1.0.0-2022.01]

--- a/demo_data/iea43_wra_data_model_demo_data.sql
+++ b/demo_data/iea43_wra_data_model_demo_data.sql
@@ -69,11 +69,11 @@ INSERT INTO measurement_point
      null, 'ground_level', null, 'be6f56e6-83f6-4460-a8b8-84c457238c86');
 
 INSERT INTO logger_measurement_config
-    (uuid, measurement_point_uuid, slope, "offset", sensitivity, measurement_units_id, height_m,
+    (uuid, slope, "offset", sensitivity, measurement_units_id, height_m,
      serial_number, connection_channel, date_from, date_to, notes, updated_by) VALUES
-    ('c48054d3-888a-405f-9009-6714e53a7fc2', '390bc20e-acb2-4ad2-adfa-65eadeb2346b', 0.04573, 0.2419, null,
+    ('c48054d3-888a-405f-9009-6714e53a7fc2', 0.04573, 0.2419, null,
      'm/s', 80, '09183000', 'CH1', '2020-04-12T12:00:00', '2020-04-15T00:00:00', null, 'be6f56e6-83f6-4460-a8b8-84c457238c86'),
-    ('b08331bd-0dc3-44cf-86f8-7ca42735bb58', '390bc20e-acb2-4ad2-adfa-65eadeb2346b', 0.04573, 0.2491, null,
+    ('b08331bd-0dc3-44cf-86f8-7ca42735bb58', 0.04573, 0.2491, null,
      'm/s', 80, '09183000', 'CH1', '2020-04-15T00:00:00', null, null, 'be6f56e6-83f6-4460-a8b8-84c457238c86');
 --    ('', '3f074548-aa9f-4e98-94c5-745ec2e26c73', 0.04568, 0.2487, null,
 --     'm/s', 80, '09183001', 'CH2', '2020-04-12T12:00:00', '2020-04-18T00:00:00', null, 'be6f56e6-83f6-4460-a8b8-84c457238c86'),
@@ -105,6 +105,11 @@ INSERT INTO logger_measurement_config
 --     'm/s', 80, '09183000', 'CH1', '2020-04-12T12:00:00', '2020-04-15T00:00:00', null, 'be6f56e6-83f6-4460-a8b8-84c457238c86'),
 --    ('', '390bc20e-acb2-4ad2-adfa-65eadeb2346b', 0.04573, 0.2419, null,
 --     'm/s', 80, '09183000', 'CH1', '2020-04-12T12:00:00', '2020-04-15T00:00:00', null, 'be6f56e6-83f6-4460-a8b8-84c457238c86');
+
+INSERT INTO measurement_point_logger_measurement_config
+    (measurement_point_uuid, logger_measurement_config_uuid) VALUES
+    ('390bc20e-acb2-4ad2-adfa-65eadeb2346b', 'c48054d3-888a-405f-9009-6714e53a7fc2'),
+    ('390bc20e-acb2-4ad2-adfa-65eadeb2346b', 'b08331bd-0dc3-44cf-86f8-7ca42735bb58');
 
 INSERT INTO column_name
     (uuid, logger_measurement_config_uuid, column_name, statistic_type_id, is_ignored, notes, updated_by) VALUES

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -154,7 +154,7 @@ INSERT INTO height_reference (id) VALUES
 INSERT INTO measurement_units (id) VALUES
     ('m/s'),
     ('mph'),
-    ('knots');
+    ('knots'),
     ('deg'),
     ('deg_C'),
     ('deg_F'),
@@ -385,7 +385,6 @@ CREATE TABLE IF NOT EXISTS measurement_point(
 
 CREATE TABLE IF NOT EXISTS logger_measurement_config(
     uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    measurement_point_uuid UUID NOT NULL,
     slope decimal,
     "offset" decimal,  -- offset is a SQL reserved word so needs to be escaped
     sensitivity decimal,
@@ -398,7 +397,6 @@ CREATE TABLE IF NOT EXISTS logger_measurement_config(
     notes text,
     update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by UUID,
-    FOREIGN KEY (measurement_point_uuid) REFERENCES measurement_point (uuid),
     FOREIGN KEY (measurement_units_id) REFERENCES measurement_units (id)
 );
 
@@ -413,6 +411,14 @@ CREATE TABLE IF NOT EXISTS column_name(
     updated_by UUID,
     FOREIGN KEY (logger_measurement_config_uuid) REFERENCES logger_measurement_config (uuid),
     FOREIGN KEY (statistic_type_id) REFERENCES statistic_type (id)
+);
+
+CREATE TABLE IF NOT EXISTS measurement_point_logger_measurement_config(
+    measurement_point_uuid UUID,
+    logger_measurement_config_uuid UUID,
+    PRIMARY KEY (measurement_point_uuid, logger_measurement_config_uuid),
+    FOREIGN KEY (measurement_point_uuid) REFERENCES measurement_point (uuid),
+    FOREIGN KEY (logger_measurement_config_uuid) REFERENCES logger_measurement_config (uuid)
 );
 
 CREATE TABLE IF NOT EXISTS sensor(


### PR DESCRIPTION
@abohara could you please review this enhancement of adding a mapping table between the measurement_point and the logger_measurement_config. This just impacts the database tool and has no impact on the Schema itself.

See issue #150 

Thanks!