### PR TITLE
iss #186 add lidar and sodar to sensor_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Additional labels for pre-release and build metadata are available as extensions
 
 1. To `sensor` object, added:
     1. `sensor_body_size_mm` (Issue [#155](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/155))
+1. To `sensor_type`:
+   1. add `lidar` (Issue [#186](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/186)),
+   2. add `sodar` (Issue [#186](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/186)).
 
 ## [1.1.0-2022.06]
 

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1171,6 +1171,8 @@
                           "illuminance_sensor",
                           "compass",
                           "solar_compass",
+                          "lidar",
+                          "sodar",
                           "other"
                         ]
                       },

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -226,6 +226,8 @@ INSERT INTO sensor_type (id) VALUES
     ('illuminance_sensor'),
     ('compass'),
     ('solar_compass'),
+    ('lidar'),
+    ('sodar'),
     ('other');
 
 INSERT INTO mounting_type (id) VALUES


### PR DESCRIPTION
As discussed in issue #186 added lidar and sodar to the sensor_type enum.

@kersting can you please review?