### PR TITLE
iss #192 add dates to mast properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional labels for pre-release and build metadata are available as extensions
 1. To `sensor_type`:
    1. add `lidar` (Issue [#186](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/186)),
    2. add `sodar` (Issue [#186](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/186)).
+1. To `mast_properties` add `date_from` and `date_to` (Issue [#192](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/192)).
 
 ## [1.1.0-2022.06]
 

--- a/demo_data/iea43_wra_data_model.json
+++ b/demo_data/iea43_wra_data_model.json
@@ -18,6 +18,8 @@
       "mast_serial_number": "MM01234",
       "mast_model": "SLX80m",
       "mast_height_m": 78.5,
+      "date_from": "2020-04-12T12:00:00",
+      "date_to": null,
       "notes": "I can write anything I want here.",
       "update_at": "2020-04-18T18:13:00",
       "mast_section_geometry": [{

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -365,6 +365,12 @@
                   81.3
                 ]
               },
+              "date_from": {
+                "$ref": "#/definitions/date_from"
+              },
+              "date_to": {
+                "$ref": "#/definitions/date_to"
+              },
               "notes": {
                 "$ref": "#/definitions/notes"
               },

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -288,6 +288,8 @@ CREATE TABLE IF NOT EXISTS mast_properties(
 CREATE TABLE IF NOT EXISTS measurement_location_mast_properties(
     measurement_location_uuid UUID,
     mast_properties_uuid UUID,
+    date_from timestamp WITHOUT TIME ZONE,
+    date_to timestamp WITHOUT TIME ZONE,
     PRIMARY KEY (measurement_location_uuid, mast_properties_uuid),
     FOREIGN KEY (measurement_location_uuid) REFERENCES measurement_location (uuid),
     FOREIGN KEY (mast_properties_uuid) REFERENCES mast_properties (uuid)


### PR DESCRIPTION
See issue #192.

This allows the user the choice to add in a second mast if the mast was reinstated the same as the first mast.