### PR TITLE
Iss #241 add cm/s and mm/s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional labels for pre-release and build metadata are available as extensions
    1. `ti30sec` (Issue [#218](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/218))
 1. To `measurement_units_id` enum add:
    1. `cm/s` (Issue [#241](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/241))
+   1. `mm/s` (Issue [#241](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/241))
 1. To `measurement_station_type` enum add:
    1. `wave_buoy` (Issue [#226](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/226))
    1. `adcp` (Issue [#226](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/226))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Additional labels for pre-release and build metadata are available as extensions
 1. To `measurement_type` add:
    1. `obukhov_length` (Issue [#182](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/182))
 1. To `statistic_type_id` enum add:
-   1. `ti30sec` (Issue [#218](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/218 ))
+   1. `ti30sec` (Issue [#218](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/218))
+1. To `measurement_units_id` enum add:
+   1. `cm/s` (Issue [#241](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/241))
 1. To `measurement_station_type` enum add:
    1. `wave_buoy` (Issue [#226](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/226))
    1. `adcp` (Issue [#226](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/226))

--- a/demo_data/floating_lidar_demo_iea43_wra_data_model.json
+++ b/demo_data/floating_lidar_demo_iea43_wra_data_model.json
@@ -498,7 +498,7 @@
       "notes": "Vertical water speed at 5m.",
       "update_at": "2022-03-31T12:13:27",
       "logger_measurement_config": [{
-        "measurement_units_id": "m/s",
+        "measurement_units_id": "cm/s",
         "height_m": 3.7,
         "date_from": "2022-03-01T12:10:00",
         "date_to": null,
@@ -506,22 +506,22 @@
         "update_at": "2022-03-31T12:13:27",
         "column_name": [
           {
-            "column_name": "Vertical Water Speed (m/s) at 3.7m",
+            "column_name": "Vertical Water Speed (cm/s) at 3.7m",
             "statistic_type_id": "avg",
             "is_ignored": false,
             "update_at": "2022-03-31T12:13:27"
           },{
-            "column_name": "Vertical Water Speed Std. Dev. (m/s) at 3.7m",
+            "column_name": "Vertical Water Speed Std. Dev. (cm/s) at 3.7m",
             "statistic_type_id": "sd",
             "is_ignored": false,
             "update_at": "2022-03-31T12:13:27"
           },{
-            "column_name": "Vertical Water Speed Min (m/s) at 3.7m",
+            "column_name": "Vertical Water Speed Min (cm/s) at 3.7m",
             "statistic_type_id": "min",
             "is_ignored": false,
             "update_at": "2022-03-31T12:13:27"
           },{
-            "column_name": "Vertical Water Speed Max (m/s) at 3.7m",
+            "column_name": "Vertical Water Speed Max (cm/s) at 3.7m",
             "statistic_type_id": "max",
             "is_ignored": false,
             "update_at": "2022-03-31T12:13:27"

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1075,6 +1075,7 @@
                         "description": "The measurement units of the values the sensor records.",
                         "enum": [
                           "m/s",
+                          "cm/s",
                           "mph",
                           "knots",
                           "deg",

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1076,6 +1076,7 @@
                         "enum": [
                           "m/s",
                           "cm/s",
+                          "mm/s",
                           "mph",
                           "knots",
                           "deg",

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -190,6 +190,7 @@ INSERT INTO height_reference (id) VALUES
 INSERT INTO measurement_units (id) VALUES
     ('m/s'),
     ('mph'),
+    ('cm/s'),
     ('knots'),
     ('deg'),
     ('deg_C'),

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -191,6 +191,7 @@ INSERT INTO measurement_units (id) VALUES
     ('m/s'),
     ('mph'),
     ('cm/s'),
+    ('mm/s'),
     ('knots'),
     ('deg'),
     ('deg_C'),


### PR DESCRIPTION
From discussion in #241 it would be good to add both cm/s and mm/s to the measurement units as water currents move a lot slower than wind so in metocean circles they use these units.

@jhs0402, could you please review this and make sure you are happy?

@abohara, when you get the chance, it would also be great if you could also review this?

I'll see about bring this up for review at the next bi-weekly call on the 7th Dec.