### PR TITLE
Add 'calc', 'fuel_gauge' and 'fuel_level'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ Additional labels for pre-release and build metadata are available as extensions
    1. `deg_C/mV` (Issue [#260](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/260))
    1. `%/V` (Issue [#260](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/260))
    1. `%/mV` (Issue [#260](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/260))
-
+1. To `sensor_type` add:
+   1. `calc` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))
+   1. `fuel_gauge` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))
+1. To `measurement_type` add:
+   1. `fuel_level` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))
 
 ## [1.3.0-2024.03]
 

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -230,6 +230,7 @@
         "azimuth (is the angle of the sun around the horizon, in the northern hemisphere this is usually measured from north and increasing eastward whereas in the southern hemisphere it can be measured from the south and increasing westward)",
         "water_level (is the height of the sea surface above the sea floor. In CF Conventions this is equivalent, but opposite in respect of their point of reference, to 'sea_floor_depth_below_sea_surface'.)",
         "depth (the vertical distance below a particular reference e.g. sea level.)",
+        "fuel_level (is the amount of fuel present in the fuel tank at any given time.)",
         "timestamp (the timestamp of when a measurement value was recorded)",
         "obukhov_length (a parameter with a dimension of length which, when used to scale the height above ground, gives a dimensionless stability parameter.)",
         "other"

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -158,6 +158,7 @@
         "azimuth",
         "water_level",
         "depth",
+        "fuel_level",
         "timestamp",
         "obukhov_length",
         "other"
@@ -1469,6 +1470,8 @@
                           "pth",
                           "lidar",
                           "sodar",
+                          "fuel_gauge",
+                          "calc",
                           "other",
                           null
                         ]

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -190,6 +190,7 @@ INSERT INTO measurement_type (id) VALUES
     ('azimuth'),
     ('water_level'),
     ('depth'),
+    ('fuel_level'),
     ('timestamp'),
     ('obukhov_length'),
     ('other');
@@ -315,6 +316,8 @@ INSERT INTO sensor_type (id) VALUES
     ('pth'),
     ('lidar'),
     ('sodar'),
+    ('fuel_gauge'),
+    ('calc'),
     ('other');
 
 INSERT INTO mounting_type (id) VALUES


### PR DESCRIPTION
From the floating lidar file format discussion #268 it was decided:

1. To `sensor_type` add:
   1. `calc` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))
   1. `fuel_gauge` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))
1. To `measurement_type` add:
   1. `fuel_level` (Discussion [#268](https://github.com/IEA-Task-43/digital_wra_data_standard/discussions/268#discussioncomment-11257819))

This can be reviewed now but probably shouldn't be merged until the floating lidar work is completed.