### PR TITLE
iss #259 rename lidar_config to remote_sensing_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
 ## [2.0.0-202X.XX]
-
+1. Rename `lidar_config` to `remote_sensing_config` (Issue [#259](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/259))
 
 
 ## [1.5.0-202X.XX]

--- a/demo_data/floating_lidar_demo_iea43_wra_data_model.json
+++ b/demo_data/floating_lidar_demo_iea43_wra_data_model.json
@@ -49,7 +49,7 @@
       "logger_acquisition_uncertainty": 0.1,
       "notes": "This is the lidar.",
       "update_at": "2022-03-31T12:13:27",
-      "lidar_config": [{
+      "remote_sensing_config": [{
         "flow_corrections_applied": false,
 	"logger_stated_device_datum_plane_height_m": 1.5,
 	"logger_stated_device_orientation_deg": null,

--- a/floating_lidar_file_format/floating_lidar_file_format_header.schema.json
+++ b/floating_lidar_file_format/floating_lidar_file_format_header.schema.json
@@ -316,10 +316,10 @@
           "notes": {
             "$ref": "#/definitions/notes"
           },
-          "lidar_config": {
+          "remote_sensing_config": {
             "type": "object",
-            "title": "Lidar Specific Configuration",
-            "description": "The lidar specific configuration represents how the lidar's specific settings are configured. For example, if FCR is turned on.",
+            "title": "Remote Sensing Device Configuration",
+            "description": "The remote sensing device configuration represents how the remote sensing device's specific settings are configured. For example, if FCR is turned on for a lidar.",
             "properties": {
               "flow_corrections_applied": {
                 "type": [

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1093,16 +1093,16 @@
                 "update_at": {
                   "$ref": "#/definitions/update_at"
                 },
-                "lidar_config": {
+                "remote_sensing_config": {
                   "type": [
                     "array",
                     "null"
                   ],
-                  "title": "Lidar Specific Configuration",
-                  "description": "The lidar specific configuration represents how the lidar's specific settings are configured. For example, if FCR is turned on.",
+                  "title": "Remote Sensing Device Configuration",
+                  "description": "The remote sensing device configuration represents how the remote sensing device's specific settings are configured. For example, if FCR is turned on for a lidar.",
                   "items": {
                     "type": "object",
-                    "title": "Lidar Specific Configuration",
+                    "title": "Remote Sensing Device Configuration",
                     "properties": {
                       "flow_corrections_applied": {
                         "type": [

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -496,7 +496,7 @@ CREATE TABLE IF NOT EXISTS logger_main_config(
     FOREIGN KEY (logger_oem_id) REFERENCES logger_oem (id)
 );
 
-CREATE TABLE IF NOT EXISTS lidar_config(
+CREATE TABLE IF NOT EXISTS remote_sensing_config(
     uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     logger_main_config_uuid UUID,
     flow_corrections_applied boolean,


### PR DESCRIPTION
## Summary
- Rename `lidar_config` to `remote_sensing_config` to reflect that properties like `logger_stated_device_datum_plane_height_m` and `logger_stated_device_orientation_deg` apply to all remote sensing devices (lidars and sodars), not just lidars (Issue #259)
- This is a **breaking change** for v2.0.0

## Changes
- **schema/iea43_wra_data_model.schema.json**: Renamed `lidar_config` key to `remote_sensing_config`, updated title and description
- **tools/iea43_wra_data_model_postgresql.sql**: Renamed `lidar_config` table to `remote_sensing_config`
- **demo_data/floating_lidar_demo_iea43_wra_data_model.json**: Updated key name from `lidar_config` to `remote_sensing_config`
- **floating_lidar_file_format/floating_lidar_file_format_header.schema.json**: Renamed `lidar_config` key to `remote_sensing_config`, updated title and description
- **CHANGELOG.md**: Added entry under `[2.0.0]` section referencing issue #259

## Test plan
- [ ] Validate that the JSON schema is still valid
- [ ] Validate the demo file against the updated schema using [jsonschemavalidator](https://www.jsonschemavalidator.net/)
- [ ] Verify PostgreSQL SQL statements are compatible with the updated schema
- [ ] Validate the floating lidar file format schema is still valid