### PR TITLE
iss #274 add leaf_wetness_sensor and leaf_surface_wetness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Additional labels for pre-release and build metadata are available as extensions
    1. `specific_conductivity` (Issue [#296](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/296))
    1. `density_anomaly` (Issue [#296](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/296))
    1. `dew_point_temperature` (Issue [#304](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/304))
+   1. `leaf_surface_wetness` (Issue [#274](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/274))
+1. To `sensor_type` add
+   1. `leaf_wetness_sensor` (Issue [#274](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/274))
 1. To `measurement_units` add 
    1. `mS/cm` (Issue [#296](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/296))
    1. `μS/cm` (Issue [#296](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/296))

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -176,6 +176,7 @@
         "speed_of_sound_in_air",
         "speed_of_sound_in_water",
         "mass_concentration",
+        "leaf_surface_wetness",
         "timestamp",
         "obukhov_length",
         "other"
@@ -265,6 +266,7 @@
         "speed_of_sound_in_air (the velocity at which acoustic waves move through the atmosphere.)",
         "speed_of_sound_in_water (the velocity at which acoustic waves move through water, such as sea water. In CF Conventions this is known as 'speed_of_sound_in_sea_water'.)",
         "mass_concentration (refers to the amount of mass of a substance (X) contained in a given volume of another substance (Y). It is expressed as mass per unit volume. In CF Conventions it typically appears in terms like mass_concentration_of_X_in_Y, where X is the material present in Y.)",
+        "leaf_surface_wetness (the presence and amount of moisture, such as dew, rain or fog, on the surface of a leaf or a leaf-like sensing element used as a proxy for vegetation wetness.)",
         "timestamp (the timestamp of when a measurement value was recorded)",
         "obukhov_length (a parameter with a dimension of length which, when used to scale the height above ground, gives a dimensionless stability parameter.)",
         "other"
@@ -1512,6 +1514,7 @@
                           "rain_gauge",
                           "ice_detection_sensor",
                           "fog_sensor",
+                          "leaf_wetness_sensor",
                           "gps",
                           "illuminance_sensor",
                           "compass",

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -210,6 +210,7 @@ INSERT INTO measurement_type (id) VALUES
     ('speed_of_sound_in_air'),
     ('speed_of_sound_in_water'),
     ('mass_concentration'),
+    ('leaf_surface_wetness'),
     ('timestamp'),
     ('obukhov_length'),
     ('other');
@@ -336,6 +337,7 @@ INSERT INTO sensor_type (id) VALUES
     ('rain_gauge'),
     ('ice_detection_sensor'),
     ('fog_sensor'),
+    ('leaf_wetness_sensor'),
     ('gps'),
     ('illuminance_sensor'),
     ('compass'),


### PR DESCRIPTION
## Summary
- Add `leaf_wetness_sensor` to the `sensor_type` enum (Issue #274)
- Add `leaf_surface_wetness` to the `measurement_type` enum (Issue #274)
- Some power performance test towers include leaf wetness sensors (e.g. [Phytos 31 from Meter Group](https://metergroup.com/products/phytos-31/))
- `leaf_wetness_sensor` follows the existing `_sensor` naming convention used by other atmospheric condition detectors (`ice_detection_sensor`, `fog_sensor`, `illuminance_sensor`)

## Changes
- **schema/iea43_wra_data_model.schema.json**: Added `leaf_wetness_sensor` to `sensor_type` enum; added `leaf_surface_wetness` to `measurement_type` enum with description in examples
- **tools/iea43_wra_data_model_postgresql.sql**: Added new values to both `sensor_type` and `measurement_type` INSERT statements
- **CHANGELOG.md**: Added entries under `[1.5.0]` referencing issue #274

## Test plan
- [ ] Validate that the JSON schema is still valid
- [ ] Validate the demo file against the updated schema using [jsonschemavalidator](https://www.jsonschemavalidator.net/)
- [ ] Verify PostgreSQL SQL statements are compatible with the updated schema