### PR TITLE
Iss318 remove enum for reanalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Additional labels for pre-release and build metadata are available as extensions
    1. rename `Kintech` to `Kintech Engineering` (Issue [#275](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/275))
    1. rename `Ammonit` to `Ammonit Measurement GmbH` (Issue [#292](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/292))
 1. In `model_config`
-   1. remove the enum constraint from `reanalysis`, allowing any string or null. The existing enum values are retained as suggested values. (Issue [#318](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/318))
+   1. remove the enum constraint from `reanalysis`, allowing any string or null. The existing enum values are retained as suggested values. `Other` has been removed as free-text input now serves this purpose. (Issue [#318](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/318))
 
 
 ## [1.4.0-2025.06]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Additional labels for pre-release and build metadata are available as extensions
 1. In `logger_oem`
    1. rename `Kintech` to `Kintech Engineering` (Issue [#275](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/275))
    1. rename `Ammonit` to `Ammonit Measurement GmbH` (Issue [#292](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/292))
+1. In `model_config`
+   1. remove the enum constraint from `reanalysis`, allowing any string or null. The existing enum values are retained as suggested values. (Issue [#318](https://github.com/IEA-Task-43/digital_wra_data_standard/issues/318))
 
 
 ## [1.4.0-2025.06]

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1193,7 +1193,7 @@
                     "null"
                   ],
                   "title": "Reanalysis",
-                  "description": "The name of the reanalysis dataset that is the source or the result of this model. In versions 1.5.0 and before this was an enum as defined by the IEA Wind Resource Assessment Data Model Schema. It is strongly advised to keep using values from this list.",
+                  "description": "The name of the reanalysis dataset that is the source or the result of this model. In WRA Data Model versions 1.4.0 and before this was an enum; it now accepts a free-text string for forward compatibility with newer datasets. It is strongly advised to use a value from the enum list, matching the dataset producer's official name, spelling and casing.",
                   "anyOf": [
                     {
                       "enum": [
@@ -1209,12 +1209,14 @@
                         "MERRA-2",
                         "NCAR",
                         "NORA3",
-                        "Other",
-                        null
+                        "Other"
                       ]
                     },
                     {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   ]
                 },

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1208,8 +1208,7 @@
                         "JRA-55",
                         "MERRA-2",
                         "NCAR",
-                        "NORA3",
-                        "Other"
+                        "NORA3"
                       ]
                     },
                     {

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1197,12 +1197,18 @@
                   "anyOf": [
                     {
                       "enum": [
+                        "BARRA",
+                        "CERRA",
                         "CFSR",
+                        "EARS",
                         "ERA-Interim",
                         "ERA5",
+                        "ERA6",
+                        "JRA-3Q",
                         "JRA-55",
                         "MERRA-2",
                         "NCAR",
+                        "NORA3",
                         "Other",
                         null
                       ]

--- a/schema/iea43_wra_data_model.schema.json
+++ b/schema/iea43_wra_data_model.schema.json
@@ -1188,17 +1188,28 @@
               "title": "Model Configuration",
               "properties": {
                 "reanalysis": {
-                  "type": "string",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "title": "Reanalysis",
-                  "description": "The name of the reanalysis dataset that is the source or the result of this model.",
-                  "enum": [
-                    "CFSR",
-                    "ERA-Interim",
-                    "ERA5",
-                    "JRA-55",
-                    "MERRA-2",
-                    "NCAR",
-                    "Other"
+                  "description": "The name of the reanalysis dataset that is the source or the result of this model. In versions 1.5.0 and before this was an enum as defined by the IEA Wind Resource Assessment Data Model Schema. It is strongly advised to keep using values from this list.",
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "CFSR",
+                        "ERA-Interim",
+                        "ERA5",
+                        "JRA-55",
+                        "MERRA-2",
+                        "NCAR",
+                        "Other",
+                        null
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
                   ]
                 },
                 "horizontal_grid_resolution_m": {

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS logger_oem (
     id text PRIMARY KEY
 );
 
+-- ** This reanalysis table is not needed from version 1.5.0 onwards and will be removed in the version 2.0 release. **
 CREATE TABLE IF NOT EXISTS reanalysis (
     id text PRIMARY KEY
 );
@@ -524,8 +525,7 @@ CREATE TABLE IF NOT EXISTS model_config(
     notes text,
     update_at timestamp WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by UUID,
-    FOREIGN KEY (measurement_location_uuid) REFERENCES measurement_location (uuid),
-    FOREIGN KEY (reanalysis_id) REFERENCES reanalysis (id)
+    FOREIGN KEY (measurement_location_uuid) REFERENCES measurement_location (uuid)
 );
 
 CREATE TABLE IF NOT EXISTS measurement_point(

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -116,12 +116,18 @@ INSERT INTO logger_oem (id) VALUES
     ('other');
 
 INSERT INTO reanalysis (id) VALUES
+    ('BARRA'),
+    ('CERRA'),
     ('CFSR'),
+    ('EARS'),
     ('ERA-Interim'),
     ('ERA5'),
+    ('ERA6'),
+    ('JRA-3Q'),
     ('JRA-55'),
     ('MERRA-2'),
     ('NCAR'),
+    ('NORA3'),
     ('Other');
 
 INSERT INTO measurement_type (id) VALUES

--- a/tools/iea43_wra_data_model_postgresql.sql
+++ b/tools/iea43_wra_data_model_postgresql.sql
@@ -127,8 +127,7 @@ INSERT INTO reanalysis (id) VALUES
     ('JRA-55'),
     ('MERRA-2'),
     ('NCAR'),
-    ('NORA3'),
-    ('Other');
+    ('NORA3');
 
 INSERT INTO measurement_type (id) VALUES
     ('wind_speed'),


### PR DESCRIPTION
From issue #318 we are removing the enum contraint for reanalysis.

We are following the same pattern as we are introducing to the logger_oem by using 'anyOf' so the list is still there and usable.

Also added a few more reanalysis names.